### PR TITLE
refactory: move build

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -33,7 +33,7 @@ pub enum Commands {
         /// If omitted, mdBook uses build.build-dir from book.toml \
         /// or defaults to `./book`.
         #[clap(long, short, value_hint = ValueHint::DirPath)]
-        dist_dir: Option<PathBuf>,
+        dest_dir: Option<PathBuf>,
         /// Root directory for the book
         #[clap(value_hint = ValueHint::DirPath)]
         dir: PathBuf,
@@ -43,12 +43,11 @@ pub enum Commands {
         /// Root directory for the book
         #[clap(value_hint = ValueHint::DirPath)]
         dir: PathBuf,
-        /// Output directory for the book\n\
         /// Relative paths are interpreted relative to the book's root directory.\n\
         /// If omitted, mdBook uses build.build-dir from book.toml \
         /// or defaults to `./book`.
         #[clap(long, short, value_hint = ValueHint::DirPath)]
-        dist_dir: Option<PathBuf>,
+        dest_dir: Option<PathBuf>,
     },
     /// The completions command is used to generate auto-completions for some common shells
     Completions {
@@ -68,7 +67,7 @@ pub enum Commands {
         /// If omitted, mdBook uses build.build-dir from book.toml \
         /// or defaults to `./book`.
         #[clap(long, short, value_hint = ValueHint::DirPath)]
-        dist_dir: Option<PathBuf>,
+        dest_dir: Option<PathBuf>,
         /// Root directory for the book
         #[clap(value_hint = ValueHint::AnyPath)]
         dir: PathBuf,
@@ -85,7 +84,7 @@ pub enum Commands {
         /// If omitted, mdBook uses build.build-dir from book.toml \
         /// or defaults to `./book`.
         #[clap(long, short, value_hint = ValueHint::DirPath)]
-        dist_dir: Option<PathBuf>,
+        dest_dir: Option<PathBuf>,
         /// Hostname to listen on for HTTP connections
         #[clap(long, short = 'n', default_value = "0.0.0.0", value_hint = ValueHint::Hostname)]
         hostname: Option<String>,
@@ -116,26 +115,26 @@ impl Commands {
                 let name = cmd.get_name().to_string();
                 generate_to(*shell, &mut cmd, name, out_dir).unwrap();
             }
-            Commands::Clean { dir, dist_dir } => {
-                clean::execute(dir.clone(), dist_dir.clone())?;
+            Commands::Clean { dir, dest_dir } => {
+                clean::execute(dir.clone(), dest_dir.clone())?;
             }
             Commands::Init { theme, title, dir } => {
                 init::execute(theme.clone(), title.clone(), dir)?
             }
             Commands::Build {
                 open,
-                dist_dir,
+                dest_dir,
                 dir,
             } => {}
             Commands::Watch {
                 open,
-                dist_dir,
+                dest_dir,
                 dir,
             } => {}
             Commands::Serve {
                 open,
                 port,
-                dist_dir,
+                dest_dir,
                 hostname,
                 dir,
             } => {}

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -1,0 +1,21 @@
+use anyhow::{Context, Error};
+
+use crate::models::Config;
+use std::path::PathBuf;
+
+pub fn execute(dir: PathBuf, dist_dir: Option<PathBuf>) -> Result<(), Error> {
+    let config = Config::from_disk("./book.toml")?;
+    let dir_to_remove = match dist_dir {
+        Some(dist_dir) => dist_dir.into(),
+        None => match config.build.as_ref().map(|b| b.build_dir.clone()) {
+            Some(build_dir) => config.book.src.join(&build_dir),
+            None => config.book.src.join(&dir),
+        },
+    };
+
+    if dir_to_remove.exists() {
+        std::fs::remove_dir_all(&dir_to_remove)
+            .with_context(|| "Unable to remove the build directory")?;
+    }
+    Ok(())
+}

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -3,10 +3,10 @@ use anyhow::{Context, Error};
 use crate::models::Config;
 use std::path::PathBuf;
 
-pub fn execute(dir: PathBuf, dist_dir: Option<PathBuf>) -> Result<(), Error> {
+pub fn execute(dir: PathBuf, dest_dir: Option<PathBuf>) -> Result<(), Error> {
     let config = Config::from_disk("./book.toml")?;
-    let dir_to_remove = match dist_dir {
-        Some(dist_dir) => dist_dir.into(),
+    let dir_to_remove = match dest_dir {
+        Some(dest_dir) => dest_dir.into(),
         None => match config.build.as_ref().map(|b| b.build_dir.clone()) {
             Some(build_dir) => config.book.src.join(&build_dir),
             None => config.book.src.join(&dir),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,4 +9,3 @@ pub fn main() -> Result<()> {
     cli.commands.execute()?;
     Ok(())
 }
-


### PR DESCRIPTION
This refactoring changes the name of the variable dest_dir and also moves the contents of the build command to commands